### PR TITLE
Add dimensions API & return dimensions from scale_and_orient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_STORE
+target

--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -37,7 +37,7 @@ function main() {
         let tStart = performance.now();
         try {
             const res = nail_salon.scale_and_orient(raw, 128, 128, true, true);
-            fs.writeFileSync(outPath, res);
+            fs.writeFileSync(outPath, res.thumbnail());
             console.log(` + ${file} -- ${(performance.now() - tStart).toFixed(3)}ms`);
             stats.successes++;
         } catch (e) {

--- a/demo.js
+++ b/demo.js
@@ -1,18 +1,20 @@
 const fs = require('fs');
-const nails = require('./nail_salon');
+const nails = require('./pkg/nail_salon');
 
 if (process.argv.length < 4) {
     console.error('Usage: node test.js <input> <output>');
     process.exit(1);
 }
 
-nails.init_panic_hook();
-const raw = fs.readFileSync(process.argv[2])
+const raw = new Uint8Array(fs.readFileSync(process.argv[2]));
 
 try {
-    const res = nails.scale_and_orient(new Uint8Array(raw), 512);
-    if (res)
-        fs.writeFileSync(process.argv[3], res);
+    const {width, height} = nails.dimensions(raw);
+    console.log("input: width:", width, "height:", height);
+
+    const res = nails.scale_and_orient(raw, 162, 246);
+    console.log("thumbnail: width:", res.width, "height:", res.height);
+    fs.writeFileSync(process.argv[3], res.thumbnail());
 } catch (e) {
     console.log(process.argv[2])
     console.log("Error:");


### PR DESCRIPTION
The dimensions API would be used to determine the dimensions for thumbnails generated by the pdf thumbnail service.