### PR TITLE
Add image_info method

### DIFF
--- a/bench/bench.ts
+++ b/bench/bench.ts
@@ -21,6 +21,7 @@ function main() {
     const stats = {
         failures: 0,
         successes: 0,
+        timing: 0,
     };
 
     const files = fs.readdirSync(in_dir)
@@ -36,12 +37,18 @@ function main() {
 
         let tStart = performance.now();
         try {
-            const res = nail_salon.scale_and_orient(raw, 128, 128, true, true);
-            fs.writeFileSync(outPath, res);
-            console.log(` + ${file} -- ${(performance.now() - tStart).toFixed(3)}ms`);
+            const thumb = nail_salon.scale_and_orient(raw, 128, 128, true, true);
+            nail_salon.image_info(thumb);
+            const timing = performance.now() - tStart;
+            stats.timing += timing;
+            console.log(` + ${file} -- ${(timing).toFixed(3)}ms`);
             stats.successes++;
+            fs.writeFileSync(outPath, thumb);
+
         } catch (e) {
-            console.error(`ERR: ${file} -- ${performance.now() - tStart}`,e);
+            const timing = performance.now() - tStart;
+            stats.timing += timing;
+            console.error(`ERR: ${file} -- ${(timing).toFixed(3)}ms`, e);
             fs.copyFileSync(origPath, badPath);
             stats.failures++;
         }

--- a/src/manicure.rs
+++ b/src/manicure.rs
@@ -284,7 +284,6 @@ export function image_info(input: Uint8Array): ImageInfo;
 #[wasm_bindgen(skip_typescript)]
 pub fn image_info(input: &[u8]) -> Result<JsValue, JsValue> {
     Ok(JsValue::from_serde(&_image_info(&input)?).unwrap())
-    // Ok(_image_info(&input)?)
 }
 
 pub fn _image_info(input: &[u8]) -> Result<ImageInfo, MultiErr> {

--- a/src/manicure.rs
+++ b/src/manicure.rs
@@ -270,7 +270,6 @@ pub struct ImageInfo {
     height: u32,
 }
 
-
 #[wasm_bindgen(typescript_custom_section)]
 const TS_APPEND_CONTENT: &'static str = r#"
 export interface ImageInfo {
@@ -281,7 +280,6 @@ export interface ImageInfo {
 
 export function image_info(input: Uint8Array): ImageInfo;
 "#;
-
 
 #[wasm_bindgen(skip_typescript)]
 pub fn image_info(input: &[u8]) -> Result<JsValue, JsValue> {
@@ -298,7 +296,11 @@ pub fn _image_info(input: &[u8]) -> Result<ImageInfo, MultiErr> {
     format.make_ascii_lowercase();
     let (width, height) = reader.into_dimensions()?;
 
-    Ok(ImageInfo{format, width, height})
+    Ok(ImageInfo {
+        format,
+        width,
+        height,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds an `image_info` function which return format and dimensions without decoding.